### PR TITLE
Add signals to QAction constructor

### DIFF
--- a/PySide2-stubs/QtWidgets.pyi
+++ b/PySide2-stubs/QtWidgets.pyi
@@ -763,11 +763,35 @@ class QAction(PySide2.QtCore.QObject):
         HighPriority             : QAction.Priority = ... # 0x100
 
     @typing.overload
-    def __init__(self, icon:PySide2.QtGui.QIcon, text:str, parent:typing.Optional[PySide2.QtCore.QObject]=...) -> None: ...
+    def __init__(
+        self,
+        icon:PySide2.QtGui.QIcon,
+        text:str,
+        parent:typing.Optional[PySide2.QtCore.QObject]=...,
+        triggered:typing.Callable=...,
+        changed:typing.Callable=...,
+        toggled:typing.Callable=...,
+        hovered:typing.Callable=...
+    ) -> None: ...
     @typing.overload
-    def __init__(self, parent:typing.Optional[PySide2.QtCore.QObject]=...) -> None: ...
+    def __init__(
+        self,
+        parent:typing.Optional[PySide2.QtCore.QObject]=...,
+        triggered:typing.Callable=...,
+        changed:typing.Callable=...,
+        toggled:typing.Callable=...,
+        hovered:typing.Callable=...
+    ) -> None: ...
     @typing.overload
-    def __init__(self, text:str, parent:typing.Optional[PySide2.QtCore.QObject]=...) -> None: ...
+    def __init__(
+        self,
+        text:str,
+        parent:typing.Optional[PySide2.QtCore.QObject]=...,
+        triggered:typing.Callable=...,
+        changed:typing.Callable=...,
+        toggled:typing.Callable=...,
+        hovered:typing.Callable=...
+    ) -> None: ...
 
     def actionGroup(self) -> PySide2.QtWidgets.QActionGroup: ...
     def activate(self, event:PySide2.QtWidgets.QAction.ActionEvent) -> None: ...


### PR DESCRIPTION
When initialize a `QObject`, it is possible to pass the values of properties and signals to `__init__` as `**kwargs`. This PR only add a few signal to the `__init__` of QAction